### PR TITLE
Updated: now with --twitter support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 gem 'weary','>= 0.7.1'
 gem 'highline', '>= 1.5.2'
+gem 'net-netrc', '>= 0.2.2'
 
 group :test do
 	gem 'rake'

--- a/bin/tumblr
+++ b/bin/tumblr
@@ -39,6 +39,7 @@ end
 publisher = {}
 publish_state = nil
 group = nil
+send_to_twitter = nil
 
 ARGV.options do |option|
   option.banner = usage
@@ -65,6 +66,7 @@ ARGV.options do |option|
   option.on('-d','--draft', 'Save the post as a draft') { publish_state = :draft }
   
   option.on('--group=GROUP','Publish to a group blog') {|value| group = value }
+  option.on('-t','--twitter[=TWEET]', 'Tweet the post (argument can be "no" (default), "auto" or the text of the tweet"') { |value| send_to_twitter = value || "auto" }
     
   option.separator ""
   
@@ -131,6 +133,7 @@ end
 post = Tumblr.parse(input)
 post.state = publish_state if publish_state
 post.group = group if group
+post.send_to_twitter = send_to_twitter if send_to_twitter
 
 response = Tumblr.execute(publisher, post)
 if response.success?

--- a/bin/tumblr
+++ b/bin/tumblr
@@ -8,11 +8,13 @@
 ## If a FILE is given, it will publish its contents. 
 ## See tumblr(5) for formatting instructions for FILE.
 ## If a URL or FILE is not given, tumblr will read from the Standard Input.
-## If tumblr reads from the Standard Input, you must authenticate with -a.
+## If tumblr reads from the Standard Input, you must authenticate with -a,
+## or add login credentials for your tumblr account to ~/.netrc.
 ##
 ##
 
 require 'optparse'
+require 'net/netrc'
 
 def usage
   File.readlines(__FILE__).
@@ -90,12 +92,16 @@ else
   STDIN.read.chomp!
 end
 
-if !STDIN.tty? && (!publisher[:email] || !publisher[:password])
-  bad_auth = %q(Error: An email address and password are required. Use 'tumblr -a' to authenticate. See 'tumblr --help' for details.)
-  abort bad_auth
-end
-
 if !publisher[:email] || !publisher[:password]
+  rc = Net::Netrc.locate('tumblr.com')
+  if rc
+    publisher[:email] = rc.login
+    publisher[:password] = rc.password
+  elsif !STDIN.tty?
+    bad_auth = %q(Error: An email address and password are required. See 'tumblr --help' for ways to supply them.)
+    abort bad_auth
+  end
+
   begin
     require 'highline/import'
   rescue LoadError

--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -18,7 +18,7 @@ class Tumblr
     end
     
     attr_reader :type, :state, :post_id, :format
-    attr_accessor :slug, :date, :group, :generator, :reblog_key
+    attr_accessor :slug, :date, :group, :generator, :reblog_key, :send_to_twitter
     
     def initialize(post_id = nil)
       @post_id = post_id if post_id


### PR DESCRIPTION
At the moment there's no global way to cause tumblr posts to be tweeted (the API documentation both says that if send-to-twitter is omitted the post won't be tweeted, and on the other hand that it will be tweeted if the account is set to tweet by default; I've emailed tumblr support to ask about this). The second patch I've just added adds a --twitter flag that sets the send-to-twitter flag globally.
