### PR TITLE
Changes header regex to not greedy form.

### DIFF
--- a/lib/tumblr.rb
+++ b/lib/tumblr.rb
@@ -71,7 +71,7 @@ class Tumblr
   # Parse a post out of a string
   def self.parse(doc)
     document = {}
-    if doc =~ /^(\s*---(.*)---\s*)/m
+    if doc =~ /^(\s*---(.*?)---\s*)/m
       document[:data] = YAML.load(Regexp.last_match[2].strip)
       document[:body] = doc.sub(Regexp.last_match[1],'').strip
     else


### PR DESCRIPTION
The regex that sorts out the header by searching for "---.*---" is a greedy regex, but "---" is valid markdown to create an <hr> element. If you have a markdown post written out that you post via tumblr and it has any such element, you end up losing all of the post above the "---".

This change is pretty simple, just switch .\* to .*? to make non-greedy.
