### PR TITLE
Bin require relative path kinda wonky

### DIFF
--- a/bin/tumblr
+++ b/bin/tumblr
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require "rubygems"
 require "bundler/setup"
-require '../lib/tumblr'
+require File.dirname(__FILE__) + "/../lib/tumblr"
 require 'thor'
 
 class TumblrCommand < Thor


### PR DESCRIPTION
Wasn't working for me because rb-env causes the relative paths to be different.  I think this would fix it to ensure it always looks in the right place.
