### PR TITLE
Add a 'list' method to the command line client that lists post ids

### DIFF
--- a/lib/tumblr/command_line_interface.rb
+++ b/lib/tumblr/command_line_interface.rb
@@ -126,22 +126,15 @@ module Tumblr
       ui_success "Post #{id} successfully deleted."
     end
 
-    desc "list", "List Tumblr post_ids and URLs for posts, optionally with a particular tag or post type"
+    desc "list", "List Tumblr post_ids and URLs for posts."
     method_option :tag, :type => :string,
                         :desc => "Post tag"
     method_option :type, :type => :string,
                          :desc => "Post type: text, quote, link, answer, video, audio, photo, chat"
     def list()
       client = get_client
-      response = client.posts(:tag => options[:tag], :type => options[:type], :filter => :text).perform
-      tumblr_error(response) unless response.success?
-      posts = response.parse["response"]["posts"]
-      post_list = Hash.new()
-      posts.each do |post|
-        post_list[post['id']] = post['post_url']
-        puts post['id'].to_s + " => " + post['post_url']
-      end
-      post_list
+      posts = Tumblr::Post.perform client.posts(:tag => options[:tag], :type => options[:type], :filter => :text)
+      y Hash[ posts.map {|post| [post.id, post.post_url]} ]
     end
 
     desc "authorize", "Authenticate and authorize the cli to post on your behalf"

--- a/lib/tumblr/command_line_interface.rb
+++ b/lib/tumblr/command_line_interface.rb
@@ -126,6 +126,24 @@ module Tumblr
       ui_success "Post #{id} successfully deleted."
     end
 
+    desc "list", "List Tumblr post_ids and URLs for posts, optionally with a particular tag or post type"
+    method_option :tag, :type => :string,
+                        :desc => "Post tag"
+    method_option :type, :type => :string,
+                         :desc => "Post type: text, quote, link, answer, video, audio, photo, chat"
+    def list()
+      client = get_client
+      response = client.posts(:tag => options[:tag], :type => options[:type], :filter => :text).perform
+      tumblr_error(response) unless response.success?
+      posts = response.parse["response"]["posts"]
+      post_list = Hash.new()
+      posts.each do |post|
+        post_list[post['id']] = post['post_url']
+        puts post['id'].to_s + " => " + post['post_url']
+      end
+      post_list
+    end
+
     desc "authorize", "Authenticate and authorize the cli to post on your behalf"
     option :port, :type => :string,
                   :default => "4567",

--- a/lib/tumblr/command_line_interface.rb
+++ b/lib/tumblr/command_line_interface.rb
@@ -134,7 +134,7 @@ module Tumblr
     def list()
       client = get_client
       posts = Tumblr::Post.perform client.posts(:tag => options[:tag], :type => options[:type], :filter => :text)
-      y Hash[ posts.map {|post| [post.id, post.post_url]} ]
+      ui_puts Hash[ posts.map {|post| [post.id, post.post_url]} ].to_yaml
     end
 
     desc "authorize", "Authenticate and authorize the cli to post on your behalf"

--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -231,6 +231,10 @@ module Tumblr
       @slug
     end
 
+    def post_url
+      @post_url
+    end
+
     # These are handy convenience methods.
 
     def markdown?


### PR DESCRIPTION
...and urls, optionally filtered by tag or post type.

Here's what the output looks like:

> $ tumblr help list
> Usage:
>  tumblr list
> 
> Options:
>  [--tag=TAG]                  # Post tag
>  [--type=TYPE]                # Post type: text, quote, link, answer, video, audio, photo, chat
>  [--credentials=CREDENTIALS]  # The file path where your Tumblr OAuth keys are stored. Defaults to ~/.tumblr.
>   [--host=HOST]                # The hostname of the blog you want to post to i.e. "YOUR-NAME.tumblr.com"
> 
> List Tumblr post_ids and URLs for posts, optionally with a particular tag or post type

Or if you actually run the command you'll get something like this (provided you've got the correct authorization, etc):

> $ tumblr list --type=quote
> 39948369647 => http://cca.elstudio.us/post/39948369647/please-just-do-this-if-you-do-nothing-else-git
> 39703564743 => http://cca.elstudio.us/post/39703564743/think-about-what-other-features-are-missing-in-the

Hope you'll find it helpful!
