### PR TITLE
Add Launchy to support multiple OS browser configs (#26)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rake", "~> 0.9.2"
 
 group :test do
   gem "rspec", "~> 2.11.0"
-  gem "webmock", "~> 1.8.5"
+  gem "webmock", "~> 1.9.0"
   gem "rack-test", "~> 0.6.1"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     tumblr-rb (2.0.0)
+      launchy (~> 2.1.2)
       sinatra (~> 1.3.2)
       thor (~> 0.16.0)
       weary (~> 1.1.0)
@@ -10,14 +11,16 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.3.2)
-    crack (0.3.1)
+    crack (0.3.2)
     diff-lcs (1.1.3)
     hpricot (0.8.6)
-    multi_json (1.3.6)
+    launchy (2.1.2)
+      addressable (~> 2.3)
+    multi_json (1.3.7)
     mustache (0.99.4)
     promise (0.3.0)
     rack (1.4.1)
-    rack-protection (1.2.0)
+    rack-protection (1.3.2)
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -36,9 +39,9 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
     simple_oauth (0.1.9)
-    sinatra (1.3.3)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
+    sinatra (1.3.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     thor (0.16.0)
     tilt (1.3.3)
@@ -48,7 +51,7 @@ GEM
       promise (~> 0.3.0)
       rack (~> 1.4.0)
       simple_oauth (~> 0.1.5)
-    webmock (1.8.11)
+    webmock (1.9.0)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
 
@@ -62,4 +65,4 @@ DEPENDENCIES
   ronn
   rspec (~> 2.11.0)
   tumblr-rb!
-  webmock (~> 1.8.5)
+  webmock (~> 1.9.0)

--- a/lib/tumblr/command_line_interface.rb
+++ b/lib/tumblr/command_line_interface.rb
@@ -164,7 +164,7 @@ module Tumblr
         :credential_path => options[:credentials]
       }
       Tumblr::Authentication.run!(sinatra_options) do |server|
-        `open http://#{options[:bind]}:#{options[:port]}/`
+        Launchy.open("http://#{options[:bind]}:#{options[:port]}/")
       end
       if has_credentials?
         ui_success "Success! Your Tumblr OAuth credentials were written to #{credentials.path}"

--- a/tumblr-rb.gemspec
+++ b/tumblr-rb.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "weary", "~> 1.1.0"
   gem.add_runtime_dependency "sinatra", "~> 1.3.2"
   gem.add_runtime_dependency "thor", "~> 0.16.0"
+  gem.add_runtime_dependency "launchy", "~> 2.1.2"
 end


### PR DESCRIPTION
As per [discussion](https://github.com/mwunsch/tumblr/issues/26) in #26, I've added Launchy support and replaced the `open` command with Launchy's public API method.

I had to update the Gemfile so that versions of `addressable` would be agreeable between Launchy and Webmock. Let me know what you think!
