### PR TITLE
Quote posts missing quote

### DIFF
--- a/lib/tumblr/client.rb
+++ b/lib/tumblr/client.rb
@@ -10,7 +10,7 @@ module Tumblr
       :state, :tags, :tweet, :date, :format, :slug, :source_url, :source_title,
       :title, :body, # Text posts
       :caption, :link, :source, :data, #Photo posts
-      :text, :quote, # Quote posts
+      :quote, # Quote posts
       :url, :description, # Link posts
       :conversation, # Chat posts
       :external_url, # Audio posts

--- a/lib/tumblr/client.rb
+++ b/lib/tumblr/client.rb
@@ -7,10 +7,10 @@ module Tumblr
     USER_AGENT = "Tumblr API Client (Ruby)/#{Tumblr::VERSION} (+http://github.com/mwunsch/tumblr)"
 
     POST_OPTIONS = [
-      :state, :tags, :tweet, :date, :format, :slug,
+      :state, :tags, :tweet, :date, :format, :slug, :source_url, :source_title,
       :title, :body, # Text posts
       :caption, :link, :source, :data, #Photo posts
-      :text, # Quote posts
+      :text, :quote, # Quote posts
       :url, :description, # Link posts
       :conversation, # Chat posts
       :external_url, # Audio posts

--- a/lib/tumblr/client.rb
+++ b/lib/tumblr/client.rb
@@ -10,7 +10,7 @@ module Tumblr
       :state, :tags, :tweet, :date, :format, :slug,
       :title, :body, # Text posts
       :caption, :link, :source, :data, #Photo posts
-      :quote, # Quote posts
+      :text, # Quote posts
       :url, :description, # Link posts
       :conversation, # Chat posts
       :external_url, # Audio posts

--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -17,7 +17,7 @@ module Tumblr
       :blog_name, :id, :post_url, :type, :timestamp, :date, :format,
       :reblog_key, :tags, :bookmarklet, :mobile, :source_url, :source_title,
       :total_posts,
-      :photos, :dialogue, :player # Post-specific response fields
+      :photos, :dialogue, :player, :text # Post-specific response fields
     ]
 
     # Some post types have several "body keys", which allow the YAML front-matter

--- a/lib/tumblr/post/quote.rb
+++ b/lib/tumblr/post/quote.rb
@@ -27,7 +27,7 @@ module Tumblr
       end
       
       def self.post_body_keys
-        [:quote,:text]
+        [:source]
       end
     end
   end

--- a/lib/tumblr/post/quote.rb
+++ b/lib/tumblr/post/quote.rb
@@ -4,6 +4,7 @@ module Tumblr
       def initialize(post_data = {})
         super(post_data)
         @type = :quote
+        @quote ||= @text
       end
 
       def quote
@@ -22,12 +23,8 @@ module Tumblr
         @source_title
       end
 
-      def text
-        @text
-      end
-      
       def self.post_body_keys
-        [:source]
+        [:quote]
       end
     end
   end

--- a/lib/tumblr/post/quote.rb
+++ b/lib/tumblr/post/quote.rb
@@ -6,8 +6,8 @@ module Tumblr
         @type = :quote
       end
 
-      def text
-        @text
+      def quote
+        @quote
       end
 
       def source
@@ -22,8 +22,12 @@ module Tumblr
         @source_title
       end
 
+      def text
+        @text
+      end
+      
       def self.post_body_keys
-        [:text]
+        [:quote,:text]
       end
     end
   end

--- a/lib/tumblr/post/quote.rb
+++ b/lib/tumblr/post/quote.rb
@@ -6,16 +6,24 @@ module Tumblr
         @type = :quote
       end
 
-      def quote
-        @quote
+      def text
+        @text
       end
 
       def source
         @source
       end
 
+      def source_url
+        @source_url
+      end
+
+      def source_title
+        @source_title
+      end
+
       def self.post_body_keys
-        [:quote]
+        [:text]
       end
     end
   end


### PR DESCRIPTION
This patch fixes a couple of problems with quote post type handling.
- Fetched quote posts were missing :source_url, :source_title and :text. I've added those.
- Posting a quote didn't allow setting of source_url and source_title. Tumblr accepts those, so I've added them
- Make the body of quote posts map to :source, rather than :quote. This change may be controversial, but I think this better because :source can contain markdown or html, and it can be longer than :quote. It's also consistently named -- quote text is called :quote in Tumblr's posting API and :text in retrieval. 
