### PR TITLE
Prefer $VISUAL over $EDITOR

### DIFF
--- a/lib/tumblr/command_line_interface.rb
+++ b/lib/tumblr/command_line_interface.rb
@@ -80,12 +80,12 @@ module Tumblr
     end
 
     desc "edit POST_ID", "Edit a post"
-    long_desc "Open up your $EDITOR to edit a published post."
+    long_desc "Open up your $VISUAL to edit a published post."
     long_desc <<-LONGDESC
       Get a post from Tumblr and edit it.
 
       Behaves similar to `git commit`, in that it will open up your editor in the foreground.
-      Look for a $TUMBLREDITOR environment variable, and if that's not found, will use $EDITOR.
+      Looks for a $TUMBLREDITOR environment variable, and if that's not found, will use $VISUAL, with a fall back to $EDITOR.
     LONGDESC
     def edit(id)
       client = get_client
@@ -224,7 +224,7 @@ module Tumblr
     end
 
     def editor
-      ENV["TUMBLREDITOR"] || ENV["EDITOR"]
+      ENV["TUMBLREDITOR"] || ENV["VISUAL"] || ENV["EDITOR"]
     end
 
     def has_credentials?

--- a/man/tumblr.1
+++ b/man/tumblr.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "TUMBLR" "1" "May 2013" "Mark Wunsch" "Tumblr Manual"
+.TH "TUMBLR" "1" "June 2013" "Mark Wunsch" "Tumblr Manual"
 .
 .SH "NAME"
 \fBtumblr\fR \- publish to tumblr\.com
@@ -30,7 +30,7 @@ Read from STDIN and post to tumblr\.
 .
 .TP
 \fBtumblr edit\fR \fIPOST_ID\fR
-Edit \fIPOST_ID\fR on tumblr\. Will open the serialized post in the foreground with $TUMBLREDITOR then $EDITOR\.
+Edit \fIPOST_ID\fR on tumblr\. Will open the serialized post in the foreground with $TUMBLREDITOR, $VISUAL, or $EDITOR (in that order)\.
 .
 .TP
 \fBtumblr fetch\fR \fIPOST_ID\fR

--- a/man/tumblr.1.html
+++ b/man/tumblr.1.html
@@ -97,7 +97,7 @@
   <var>URL</var> will create a link-type post, or a video or audio post, depending on the location of the url.</p></dd>
 <dt><code>tumblr pipe</code></dt><dd><p>  Read from STDIN and post to tumblr.</p></dd>
 <dt><code>tumblr edit</code> <var>POST_ID</var></dt><dd><p>  Edit <var>POST_ID</var> on tumblr.
-  Will open the serialized post in the foreground with $TUMBLREDITOR then $EDITOR.</p></dd>
+  Will open the serialized post in the foreground with $TUMBLREDITOR, $VISUAL, or $EDITOR (in that order).</p></dd>
 <dt><code>tumblr fetch</code> <var>POST_ID</var></dt><dd><p>  Fetch <var>POST_ID</var> from tumblr and write out its serialized form.</p></dd>
 <dt><code>tumblr delete</code> <var>POST_ID</var></dt><dd><p>  Delete <var>POST_ID</var> from tumblr.</p></dd>
 <dt><code>tumblr list</code></dt><dd><p>Print a YAML listing of Post IDs to Post URLs.</p></dd>
@@ -182,7 +182,7 @@ Alternatively, use the <code>$TUMBLRCRED</code> environment variable.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'>Mark Wunsch</li>
-    <li class='tc'>May 2013</li>
+    <li class='tc'>June 2013</li>
     <li class='tr'>tumblr(1)</li>
   </ol>
 

--- a/man/tumblr.1.ronn
+++ b/man/tumblr.1.ronn
@@ -26,7 +26,7 @@ If you preface your plaintext file with a bit of YAML (<yaml.org>) frontmatter, 
 
 * `tumblr edit` <POST_ID>:
 	Edit <POST_ID> on tumblr.
-	Will open the serialized post in the foreground with $TUMBLREDITOR then $EDITOR.
+	Will open the serialized post in the foreground with $TUMBLREDITOR, $VISUAL, or $EDITOR (in that order).
 
 * `tumblr fetch` <POST_ID>:
 	Fetch <POST_ID> from tumblr and write out its serialized form.


### PR DESCRIPTION
Just like git and other classic unix programs, prefer the visual editor
as specified in `$VISUAL` over the more minimal `$EDITOR`.

Here's a very quick explanation of the difference: http://unix.stackexchange.com/questions/4859/visual-vs-editor-whats-the-difference#answer-4861
