### PR TITLE
Fixed warnings that occur with Ruby 2.0

### DIFF
--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -181,7 +181,7 @@ module Tumblr
     def request_parameters
       Hash[(Tumblr::Client::POST_OPTIONS | [:id, :type]).map {|key|
         [key.to_s, send(key)] if respond_to?(key) && send(key)
-      }]
+      }.compact]
     end
 
     # Which parts of this post represent it's meta data (eg. they're not part of the body).

--- a/lib/tumblr/version.rb
+++ b/lib/tumblr/version.rb
@@ -1,3 +1,3 @@
 module Tumblr
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
Pretty simple fix... just needed to compact the array. 
